### PR TITLE
Oracle Java -> AWS Corretto

### DIFF
--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -6,7 +6,7 @@ export CATALINA_OPTS="-DMONGODB_SERVICE_HOST={{bind.database.first.sys.ip}}
 -DMONGODB_DATABASE={{cfg.mongodb_database}}"
 {{/if ~}}
 
-export JAVA_HOME="{{pkgPathFor "core/jre8"}}"
+export JAVA_HOME="{{pkgPathFor "core/corretto"}}"
 export TOMCAT_HOME="{{pkgPathFor "core/tomcat8"}}/tc"
 cp {{pkg.path}}/*.war $TOMCAT_HOME/webapps
 exec ${TOMCAT_HOME}/bin/catalina.sh run

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -4,8 +4,8 @@ pkg_origin=scottford
 pkg_version=7.0.0
 pkg_maintainer="Scott Ford <sford@chef.io>"
 pkg_license=('Apache-2.0')
-pkg_deps=(core/tomcat8 core/jre8 core/mongo-tools)
-pkg_build_deps=(core/jdk8/8u131 core/maven)
+pkg_deps=(core/tomcat8 core/corretto core/mongo-tools)
+pkg_build_deps=(core/corretto core/maven)
 pkg_svc_user="root"
 pkg_binds=(
   [database]="port"
@@ -17,7 +17,7 @@ pkg_exposes=(port)
 
 do_prepare()
 {
-    export JAVA_HOME=$(hab pkg path core/jdk8)
+    export JAVA_HOME=$(hab pkg path core/corretto)
 }
 
 do_build()


### PR DESCRIPTION
Oracle have changed the licensing on Java JRE/JDK.  As a result we need to move to a different JDK/JRE distribution.  This PR moves this project to the AWS built and maintained OSS JRE/JDK distro called `corretto`.