### PR TITLE
Fixing dev channel installs, and disabling tls for events.

### DIFF
--- a/terraform/chef-automate/aws/templates/chef_automate/install_chef_automate_cli.sh.tpl
+++ b/terraform/chef-automate/aws/templates/chef_automate/install_chef_automate_cli.sh.tpl
@@ -13,7 +13,7 @@ if [[ $? != 0 ]]; then
 fi
 
 pushd "/tmp"
-  curl https://packages.chef.io/files/current/automate/latest/chef-automate_linux_amd64.zip |gunzip - > chef-automate && chmod +x chef-automate
+  curl https://packages.chef.io/files/${channel}/automate/latest/chef-automate_linux_amd64.zip |gunzip - > chef-automate && chmod +x chef-automate
   mv chef-automate /usr/sbin/chef-automate
   mkdir -p /etc/chef-automate
 

--- a/terraform/chef-automate/aws/terraform.tfvars.example
+++ b/terraform/chef-automate/aws/terraform.tfvars.example
@@ -33,6 +33,10 @@ tag_application=""
 
 automate_hostname="yourname-a2.chef-demo.com"
 automate_license = <YOUR AUTOMATE LICENSE>
+# Requires at least 20190603162928, which isn't in current yet as of this commit. Uncomment if you need the dev channel.
+# channel = "dev"
+# TLS is not supported in the event stream beta. Uncomment until TLS is supported.
+# disable_event_tls = "true"
 
 // NOTE: If you have an acm cert and r53 managed hosted zone, you
 // can use chef_automate_alb.tf.example to build out an ALB with SSL

--- a/terraform/chef-automate/aws/variables.tf
+++ b/terraform/chef-automate/aws/variables.tf
@@ -94,6 +94,11 @@ variable "channel" {
   description = "channel is the habitat channel which will be used for installing A2"
 }
 
+variable "disable_event_tls" {
+  default="false"
+  description = "In its initial state, the events feed does not support tls. Parameterizing to make life easy later."
+}
+
 variable "automate_hostname" {
   description = "automate_hostname is the hostname which will be given to your A2 instance"
 }


### PR DESCRIPTION
Minor update to ensure:

- The dev channel, when set, is consistently used. If the current CLI tool is installed, but the dev channel is selected, bad things happen. This fixes it.

- Ensures that a toml config is created to disable tls for the event stream, with examples in the tfvars file with explanatory comments.