### PR TITLE
Add data-collector endpoint to server_url

### DIFF
--- a/terraform/templates/config_linux.toml
+++ b/terraform/templates/config_linux.toml
@@ -6,5 +6,5 @@ log_level = "warn"
 
 [data_collector]
 enable = "true"
-server_url = "${automate_url}"
+server_url = "${automate_url}/data-collector/v0/"
 token = "${automate_token}"

--- a/terraform/templates/config_windows.toml
+++ b/terraform/templates/config_windows.toml
@@ -1,4 +1,4 @@
 [data_collector]
 enable = "true"
-server_url = "${automate_url}"
+server_url = "${automate_url}/data-collector/v0/"
 token = "${automate_token}"


### PR DESCRIPTION
When spinning this up, I noticed that only the Effortless Audit package is reporting data into Automate. This is because the `user.toml` file created for the Effortless Config package is missing the required `/data-collector/v0/` endpoint in the `server_url` setting.