### PR TITLE
Terraform update/fixes for national parks

### DIFF
--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "> 0.11.0"
+  required_version = "> 0.11.00"
 }
 
 # Configure the Microsoft Azure Provider
@@ -54,7 +54,7 @@ resource "azurerm_public_ip" "permanent-peer-pip" {
   name                         = "${var.tag_name}-${var.application}-permanent-peer-pip"
   location                     = "${var.azure_region}"
   resource_group_name          = "${azurerm_resource_group.rg.name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "Static"
 
   tags {
     X-Dept        = "${var.tag_dept}"
@@ -70,7 +70,7 @@ resource "azurerm_public_ip" "mongodb-pip" {
   name                         = "${var.tag_name}-${var.application}-mongodb-pip"
   location                     = "${var.azure_region}"
   resource_group_name          = "${azurerm_resource_group.rg.name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "Static"
 
   tags {
     X-Dept        = "${var.tag_dept}"
@@ -86,7 +86,7 @@ resource "azurerm_public_ip" "haproxy-pip" {
   name                         = "${var.tag_name}-${var.application}-haproxy-pip"
   location                     = "${var.azure_region}"
   resource_group_name          = "${azurerm_resource_group.rg.name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "Static"
   tags {
     X-Dept        = "${var.tag_dept}"
     X-Customer    = "${var.tag_customer}"
@@ -101,7 +101,7 @@ resource "azurerm_public_ip" "pip" {
   name                         = "${var.tag_name}-${var.application}-pip-${count.index}"
   location                     = "${var.azure_region}"
   resource_group_name          = "${azurerm_resource_group.rg.name}"
-  public_ip_address_allocation = "static"
+  allocation_method            = "Static"
   count                        = "${var.count}"
 
   tags {

--- a/terraform/azure/tfvars.example
+++ b/terraform/azure/tfvars.example
@@ -6,7 +6,7 @@ azure_private_key_path= "~/path_to_private_key"
 
 azure_image_user = "azureuser"
 
-azuer_image_password = "Azur3pa$$word"
+azure_image_password = "Azur3pa$$word"
 
 azure_sub_id = "yourSubIDHere"
 
@@ -28,9 +28,8 @@ count = "1"
 
 tag_name = "YourFirstAndLastHere" # example: damienoneal or doneal
 
-tag_dept = "YourDepartmentHere" 
+tag_dept = "YourDepartmentHere"
 
 tag_contact = "YourEmailHere"
 
 tag_application = "AppNameeHere"
-


### PR DESCRIPTION
upated main.tf to use allocation method for public key ip's
corrected spelling of azure_image_password from azuer_image_password in tfvars.example

Signed-off-by: Alain Lubin <alubin@chef.io>