### PR TITLE
Open port 4222 on the automate server for event feeds.

### DIFF
--- a/terraform/chef-automate/aws/chef_automate.tf
+++ b/terraform/chef-automate/aws/chef_automate.tf
@@ -89,6 +89,20 @@ resource "aws_security_group_rule" "ingress_chef_automate_allow_443_tcp" {
   security_group_id = "${aws_security_group.chef_automate.id}"
 }
 
+# Chef Habitat Event Stream
+# NOTE: This is being opened on the Chef Automate Server, rather than on the ELB. 
+# Since TLS is not currently supported, this lets us connect directly over the IP address
+# This will likely need to change as the apps feature matures.
+
+resource "aws_security_group_rule" "ingress_chef_automate_allow_4222_tcp" {
+  type              = "ingress"
+  from_port         = 4222
+  to_port           = 4222
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.chef_automate.id}"
+}
+
 # Allow etcd communication
 resource "aws_security_group_rule" "ingress_chef_automate_allow_2379_tcp" {
   type                     = "ingress"


### PR DESCRIPTION
To stream Chef Habitat data to chef automate, habitat must be able to connect over port 4222. Since this opens things up on the automate server itself, app instances will connect directly to the automate IP address, rather than to the ELB, as I've not figured out proxy authentication yet, and we have TLS disabled.

Will commit the updates for the hab supervisor in a separate PR.