### PR TITLE
lower chef-client interval to 5 minutes with 30 second splay for demo

### DIFF
--- a/terraform/templates/config_linux.toml
+++ b/terraform/templates/config_linux.toml
@@ -1,5 +1,5 @@
-interval = 1800
-splay = 900
+interval = 300
+splay = 30
 splay_first_run = 0
 run_lock_timeout = 1800
 log_level = "warn"


### PR DESCRIPTION
30 minute interval is appropriate for production use cases but not for a demo environment. I'm lowering the interval to 5 minutes with a 30 second splay so chef-client data appears in the chef-client tab much sooner. This should allow you to use the demo faster and provide more data in the UI. 

Signed-off-by: ericcalabretta <eric.calabretta@gmail.com>