### PR TITLE
fix TF plan merge conflict & merge to master

### DIFF
--- a/terraform/chef-automate/aws/data.tf
+++ b/terraform/chef-automate/aws/data.tf
@@ -1,10 +1,6 @@
 
 terraform {
-<<<<<<< HEAD
-  required_version = "= 0.11.14" // Terraform frequently puts breaking changes into minor and patch version releases. _Always_ hard pin to the latest known and tested working version. Do not trust semantic versioning.
-=======
   required_version = "~> 0.11" // Terraform frequently puts breaking changes into minor and patch version releases. _Always_ hard pin to the latest known and tested working version. Do not trust semantic versioning.
->>>>>>> e3d697c6ce00e1e2b2226146dd11f9ab1245445d
 }
 
 provider "aws" {


### PR DESCRIPTION
Fixing what looks like merge conflict text being committed to master. This seems like a version control error. 

You will receive an error from the `data.tf` currently. 

````
Error: Error parsing /Users/ecalabretta/hab-repo/national-parks-demo/terraform/chef-automate/aws/data.tf: At 3:3: invalid characters in heredoc anchor
```

Signed-off-by: ericcalabretta <eric.calabretta@gmail.com>