### PR TITLE
Smford22/mongodb update

### DIFF
--- a/.studiorc
+++ b/.studiorc
@@ -1,0 +1,5 @@
+install_mongodb() {
+  hab pkg install core/mongodb/3.2.10/20171016003652
+}
+
+install_mongodb

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In order run this repo, you must first install Habitat. You can find setup docs 
 5. `build`
 6. `source results/last_build.env`
 7. Load `core/mongodb` package from the public depot:  
-  `hab svc load core/mongodb`
+  `hab svc load core/mongodb/3.2.10/20171016003652`
 8. Override the default configuration of mongodb:
    `hab config apply mongodb.default $(date +%s) mongo.toml`
 9. Load the most recent build of national-parks: 

--- a/terraform/aws/national-parks.tf
+++ b/terraform/aws/national-parks.tf
@@ -152,7 +152,7 @@ resource "aws_instance" "mongodb" {
       "sudo cp /home/${var.aws_ami_user}/mongo.toml /hab/user/mongodb/config/user.toml",
       "sudo hab svc load effortless/config-baseline --group ${var.group} --strategy at-once --channel stable",
       "sudo hab svc load effortless/audit-baseline --group ${var.group} --strategy at-once --channel stable",  
-      "sudo hab svc load core/mongodb --group ${var.group}"
+      "sudo hab svc load core/mongodb/3.2.10/20171016003652 --group ${var.group}"
     ]
 
   }

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -557,7 +557,7 @@ resource "azurerm_virtual_machine" "mongodb" {
       "sudo cp /home/${var.azure_image_user}/mongo.toml /hab/user/mongodb/config/user.toml",
       "sudo hab svc load effortless/audit-baseline --channel stable --strategy at-once --group ${var.group}",
       "sudo hab svc load effortless/config-baseline --channel stable --strategy at-once --group ${var.group}",
-      "sudo hab svc load core/mongodb --group ${var.group}"
+      "sudo hab svc load core/mongodb/3.2.10/20171016003652 --group ${var.group}"
     ]
   }
 


### PR DESCRIPTION
This commit addresses [Issue 41](https://github.com/chef-cft/national-parks-demo/issues/41) by pinning the mongodb package to version `core/mongodb/3.2.10/20171016003652`. Terraform code has been updated. Also added a `.studiorc` that will install the correct mongodb package when yo start the studio. Demoers will just need to run `hab svc load core/mongodb` and it will load the installed package.