### PR TITLE
update logic for IAMv1 and V2

### DIFF
--- a/terraform/chef-automate/aws/templates/chef_automate/set_chef_automate_token.sh.tpl
+++ b/terraform/chef-automate/aws/templates/chef_automate/set_chef_automate_token.sh.tpl
@@ -1,9 +1,16 @@
 #!/bin/bash
 
-echo "Adding hardcoded api token"
-export TOKEN=`sudo chef-automate admin-token`
+if [ "$(sudo chef-automate iam version)" = 'IAM v2.1' ]
+then
+  export TOKEN=`sudo chef-automate iam token create demo --admin`
+  echo version 2.1!
+fi
 
-echo "setting automate_token"
+if [ "$(sudo chef-automate iam version)" = 'IAM v1.0' ]
+then
+  export TOKEN=`sudo chef-automate admin-token`
+  echo version 1.0!
+fi
 
 curl -X POST \
   https://localhost/api/v0/auth/tokens \

--- a/terraform/chef-automate/aws/templates/chef_automate/set_chef_automate_token.sh.tpl
+++ b/terraform/chef-automate/aws/templates/chef_automate/set_chef_automate_token.sh.tpl
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-if [ "$(sudo chef-automate iam version)" = 'IAM v2.1' ]
+if [[ "$(sudo chef-automate iam version)" = "IAM v2."* ]]
 then
   export TOKEN=`sudo chef-automate iam token create demo --admin`
-  echo version 2.1!
+  echo version 2.x!
 fi
 
 if [ "$(sudo chef-automate iam version)" = 'IAM v1.0' ]


### PR DESCRIPTION
Updates the script we use to create the Automate key to be compatible with IAMv1 and IAMv2

We can remove it in a few weeks after the migration, but this will stop any breakage next Monday. 

Signed-off-by: ericcalabretta <eric.calabretta@gmail.com>