### PR TITLE
Update set_chef_automate_token.sh.tpl

### DIFF
--- a/terraform/chef-automate/aws/templates/chef_automate/set_chef_automate_token.sh.tpl
+++ b/terraform/chef-automate/aws/templates/chef_automate/set_chef_automate_token.sh.tpl
@@ -8,7 +8,7 @@ curl -X POST \
   https://localhost/apis/iam/v2/tokens \
   --insecure \
   -H "api-token: $TOKEN" \
-  -d '{"name":"national-parks","value": "${automate_token}","description": "national-parks","active": true, "id": "national-parks"}'
+  -d '{"name":"national-parks", "value": "${automate_token}", "active": true, "id": "national-parks"}'
 
 echo setting API policies
 


### PR DESCRIPTION
removed `description` from the token generate API request since this is not a proper request. 

A recent breaking change was made to automate API that throws an error for any extra _invalid_ fields. 