### PR TITLE
Update automate azure plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ results/
 *tfvars
 *tfstate*
 .kitchen
+.DS_Store
+terraform/chef-automate/azure/UpdateDisk.ps1

--- a/terraform/chef-automate/azure/chef_automate_lb.tf
+++ b/terraform/chef-automate/azure/chef_automate_lb.tf
@@ -20,7 +20,7 @@ resource "azurerm_availability_set" "avset" {
   resource_group_name          = azurerm_resource_group.rg.name
   platform_fault_domain_count  = 2
   platform_update_domain_count = 2
-  #managed                      = true
+  managed                      = true
 }
 
 resource "azurerm_lb" "automate_lb" {

--- a/terraform/chef-automate/azure/resource_group.tf
+++ b/terraform/chef-automate/azure/resource_group.tf
@@ -49,14 +49,14 @@ resource "azurerm_subnet" "frontend" {
   name                 = "chef-automate-${random_id.instance_id.hex}-frontend-subnet"
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnet.name
-  address_prefix       = "10.0.10.0/24"
+  address_prefixes       = ["10.0.10.0/24"]
 }
 
 resource "azurerm_subnet" "backend" {
   name                 = "chef-automate-${random_id.instance_id.hex}-backend-subnet"
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnet.name
-  address_prefix       = "10.0.20.0/24"
+  address_prefixes       = ["10.0.20.0/24"]
 }
 
 # Generate random text for a unique storage account name
@@ -90,7 +90,6 @@ resource "azurerm_storage_account" "stor" {
 
 resource "azurerm_storage_container" "storcont" {
   name                  = "vhds"
-  resource_group_name   = azurerm_resource_group.rg.name
   storage_account_name  = azurerm_storage_account.stor.name
   container_access_type = "private"
 }

--- a/terraform/chef-automate/azure/ssl_certificates.tf
+++ b/terraform/chef-automate/azure/ssl_certificates.tf
@@ -15,7 +15,9 @@ resource "acme_certificate" "automate_cert" {
   account_key_pem           = acme_registration.reg.account_key_pem
   common_name               = "${azurerm_dns_a_record.automate_lb_dns.name}.${azurerm_dns_a_record.automate_lb_dns.zone_name}"
   subject_alternative_names = ["${var.automate_hostname}-fe.${azurerm_dns_a_record.automate_lb_dns.zone_name}"]
-
+  
+  recursive_nameservers = ["8.8.8.8:53"]
+  
   dns_challenge {
     provider = "azure"
 

--- a/terraform/chef-automate/azure/templates/chef_automate/set_chef_automate_token.sh.tpl
+++ b/terraform/chef-automate/azure/templates/chef_automate/set_chef_automate_token.sh.tpl
@@ -1,19 +1,20 @@
 #!/bin/bash
+echo making admin token via cli
+export TOKEN=`sudo chef-automate iam token create cli --admin`
 
-echo "Adding hardcoded api token"
-export TOKEN=`sudo chef-automate admin-token`
-
-echo "setting automate_token"
+echo setting speciifc token value via API
 
 curl -X POST \
-  https://localhost/api/v0/auth/tokens \
+  https://localhost/apis/iam/v2/tokens \
   --insecure \
   -H "api-token: $TOKEN" \
-  -d '{"value": "${automate_token}","description": "From Terraform","active": true, "id": "00000000-0000-0000-0000-000000000000"}'
+  -d '{"name":"national-parks", "value": "${automate_token}", "active": true, "id": "national-parks"}'
+
+echo setting API policies
 
 curl -s \
-  https://localhost/api/v0/auth/policies \
+  https://localhost/apis/iam/v2/policies/ingest-access/members:add \
   --insecure \
   -H "api-token: $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"subjects":["token:00000000-0000-0000-0000-000000000000"], "action":"*", "resource":"compliance:*"}'
+  -d '{"members":["token:national-parks"]}'


### PR DESCRIPTION
Changes in this PR:

- Updated Azure resources in the chef-automate/azure plan to align to new Terraform 12 standards
- Included updates to Chef Automate token API calls which had not been updated for Azure
- Fixed issue with Automate hostname not being updated for the SSH provisioner

Tested by deploying the Azure Chef Automate plan.


