### PR TITLE
[NationalParksDemo][Bugfix] - Unpin and change corretto version

### DIFF
--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -6,7 +6,7 @@ export CATALINA_OPTS="-DMONGODB_SERVICE_HOST={{bind.database.first.sys.ip}}
 -DMONGODB_DATABASE={{cfg.mongodb_database}}"
 {{/if ~}}
 
-export JAVA_HOME="{{pkgPathFor "core/corretto"}}"
+export JAVA_HOME="{{pkgPathFor "core/corretto8"}}"
 export TOMCAT_HOME="{{pkgPathFor "core/tomcat8"}}/tc"
 cp {{pkg.path}}/*.war $TOMCAT_HOME/webapps
 exec ${TOMCAT_HOME}/bin/catalina.sh run

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -4,8 +4,8 @@ pkg_origin=ericheiser
 pkg_version=7.0.0
 pkg_maintainer="Eric Heiser <eheiser@chef.io>"
 pkg_license=('Apache-2.0')
-pkg_deps=(core/tomcat8 core/corretto/11.0.2.9.3 core/mongo-tools)
-pkg_build_deps=(core/corretto/11.0.2.9.3 core/maven)
+pkg_deps=(core/tomcat8 core/corretto8 core/mongo-tools)
+pkg_build_deps=(core/corretto8 core/maven)
 pkg_svc_user="root"
 pkg_binds=(
   [database]="port"
@@ -17,7 +17,7 @@ pkg_exposes=(port)
 
 do_prepare()
 {
-    export JAVA_HOME=$(hab pkg path core/corretto/11.0.2.9.3)
+    export JAVA_HOME=$(hab pkg path core/corretto8)
 }
 
 do_build()


### PR DESCRIPTION
This unpins the corretto11 version and switches to corretto8, this should fix #81 / #82.

Tested locally, service loaded and displayed results.

Signed-off-by: Steven Marshall <SMarshall@chef.io>